### PR TITLE
Fix error that occurs if proxy has no target

### DIFF
--- a/src/main/java/io/apigee/buildTools/enterprise4g/dep/flowfrag/FlowFragmentProcessor.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/dep/flowfrag/FlowFragmentProcessor.java
@@ -42,7 +42,9 @@ public class FlowFragmentProcessor {
     private List<File> getAllProxyXMLFiles() {
         ArrayList<File> xmlFiles = new ArrayList<File>();
         for (File proxyDir : proxyDirs) {
-            xmlFiles.addAll(FileUtils.listFiles(proxyDir, new String[]{"xml"}, false));
+            if (proxyDir.isDirectory()) {
+                xmlFiles.addAll(FileUtils.listFiles(proxyDir, new String[]{"xml"}, false));
+            }
         }
         return xmlFiles;
     }

--- a/src/main/java/io/apigee/buildTools/enterprise4g/dep/policy/PolicyDependencyProcessor.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/dep/policy/PolicyDependencyProcessor.java
@@ -58,7 +58,9 @@ public class PolicyDependencyProcessor {
     private List<File> getAllProxyXMLFiles() {
         ArrayList<File> xmlFiles = new ArrayList<File>();
         for (File proxyDir : proxyDirs) {
-            xmlFiles.addAll(FileUtils.listFiles(proxyDir, new String[]{"xml"}, false));
+            if (proxyDir.isDirectory()) {
+                xmlFiles.addAll(FileUtils.listFiles(proxyDir, new String[]{"xml"}, false));
+            }
         }
         return xmlFiles;
     }


### PR DESCRIPTION
This commit fixes an issue where the plugin would fail if the proxy has no `targets`, such as when the proxy itself is returning the response payload.

Fixes #22
